### PR TITLE
To next middleware

### DIFF
--- a/lib/reloadify.js
+++ b/lib/reloadify.js
@@ -32,6 +32,8 @@ function reloadify(dir) {
         res.setHeader('cache-control', 'no-cache');
 
         inject(req, res, next);
+      } else {
+        next();
       }
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reloadify",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A live-reload NPM module that works well with your raw Node / Express servers. CLI version available as well.",
   "main": "server.js",
   "bin": "bin/cli.js",


### PR DESCRIPTION
Reloadify had a bug that when express used a method different than GET, like POST, then reloadify wouldn't continue to the next layer.
